### PR TITLE
Add GitHub PR pagination utility with tests

### DIFF
--- a/tests/github-pr-list/package.json
+++ b/tests/github-pr-list/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@tests/github-pr-list",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@extension/tsconfig": "workspace:*",
+    "nock": "^13.5.0",
+    "node-fetch": "^3.3.2",
+    "vitest": "^1.5.0",
+    "typescript": "^5"
+  }
+}

--- a/tests/github-pr-list/src/github_pr_list_paginated.ts
+++ b/tests/github-pr-list/src/github_pr_list_paginated.ts
@@ -1,0 +1,111 @@
+import fetch from 'node-fetch';
+
+export interface PullRequest {
+  number: number;
+  title: string;
+  state: string;
+  url: string;
+  author: string;
+  mergedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ListAllPullRequestsOptions {
+  owner: string;
+  name: string;
+  token: string;
+  states?: ('OPEN' | 'CLOSED' | 'MERGED')[];
+  perPage?: number;
+  maxPages?: number;
+}
+
+export async function listAllPullRequests(opts: ListAllPullRequestsOptions): Promise<PullRequest[]> {
+  const {
+    owner,
+    name,
+    token,
+    states = ['OPEN'],
+    perPage = 50,
+    maxPages = 100
+  } = opts;
+
+  let after: string | null = null;
+  let pagesFetched = 0;
+  const all: PullRequest[] = [];
+
+  while (pagesFetched < maxPages) {
+    const query = `
+      query ($owner:String!, $name:String!, $states:[PullRequestState!], $first:Int!, $after:String) {
+        repository(owner:$owner, name:$name) {
+          pullRequests(states:$states, first:$first, after:$after, orderBy:{ field: UPDATED_AT, direction: DESC }) {
+            nodes {
+              number
+              title
+              state
+              url
+              author { login }
+              mergedAt
+              createdAt
+              updatedAt
+            }
+            pageInfo {
+              endCursor
+              hasNextPage
+            }
+          }
+        }
+      }
+    `;
+
+    const variables: Record<string, any> = {
+      owner,
+      name,
+      states,
+      first: perPage,
+      after
+    };
+
+    const res = await fetch('https://api.github.com/graphql', {
+      method: 'POST',
+      headers: {
+        Authorization: `bearer ${token}`,
+        'Content-Type': 'application/json',
+        'User-Agent': 'mcp-github-tools'
+      },
+      body: JSON.stringify({ query, variables })
+    });
+
+    if (!res.ok) {
+      throw new Error(`GitHub GraphQL API responded with ${res.status}: ${res.statusText}`);
+    }
+
+    const json = await res.json();
+    if (json.errors) {
+      throw new Error(`GraphQL errors: ${JSON.stringify(json.errors)}`);
+    }
+
+    const connection = json.data.repository.pullRequests;
+    const nodes = connection.nodes as any[];
+
+    nodes.forEach(n => {
+      all.push({
+        number: n.number,
+        title: n.title,
+        state: n.state,
+        url: n.url,
+        author: n.author?.login,
+        mergedAt: n.mergedAt,
+        createdAt: n.createdAt,
+        updatedAt: n.updatedAt
+      });
+    });
+
+    if (!connection.pageInfo.hasNextPage) break;
+
+    after = connection.pageInfo.endCursor;
+    pagesFetched += 1;
+  }
+
+  return all;
+}

--- a/tests/github-pr-list/tests/github_pr_list.pagination.test.ts
+++ b/tests/github-pr-list/tests/github_pr_list.pagination.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import nock from 'nock';
+import { listAllPullRequests, PullRequest } from '../src/github_pr_list_paginated';
+
+describe('listAllPullRequests', () => {
+  it('fetches all pages of pull requests', async () => {
+    const owner = 'octocat';
+    const name = 'hello-world';
+    const token = 'ghp_test';
+
+    const graphqlPath = '/graphql';
+
+    // Helper to match successive requests regardless of cursor value
+    const queryInterceptor = (body: any) => {
+      return body.query.includes('pullRequests') && body.variables.owner === owner;
+    };
+
+    // First page: one PR and a cursor indicating more pages
+    nock('https://api.github.com')
+      .post(graphqlPath, queryInterceptor)
+      .reply(200, {
+        data: {
+          repository: {
+            pullRequests: {
+              nodes: [
+                {
+                  number: 1,
+                  title: 'feat: add hello world',
+                  state: 'OPEN',
+                  url: 'https://github.com/octocat/hello-world/pull/1',
+                  author: { login: 'alice' },
+                  mergedAt: null,
+                  createdAt: '2025-07-30T00:00:00Z',
+                  updatedAt: '2025-07-30T00:01:00Z'
+                }
+              ],
+              pageInfo: {
+                endCursor: 'CURSOR1',
+                hasNextPage: true
+              }
+            }
+          }
+        }
+      });
+
+    // Second (final) page: another PR, hasNextPage = false
+    nock('https://api.github.com')
+      .post(graphqlPath, queryInterceptor)
+      .reply(200, {
+        data: {
+          repository: {
+            pullRequests: {
+              nodes: [
+                {
+                  number: 2,
+                  title: 'fix: improve docs',
+                  state: 'OPEN',
+                  url: 'https://github.com/octocat/hello-world/pull/2',
+                  author: { login: 'bob' },
+                  mergedAt: null,
+                  createdAt: '2025-07-30T00:02:00Z',
+                  updatedAt: '2025-07-30T00:03:00Z'
+                }
+              ],
+              pageInfo: {
+                endCursor: null,
+                hasNextPage: false
+              }
+            }
+          }
+        }
+      });
+
+    const prs: PullRequest[] = await listAllPullRequests({ owner, name, token, states: ['OPEN'], perPage: 1 });
+
+    expect(prs).toHaveLength(2);
+    expect(prs.map(p => p.number)).toEqual([1, 2]);
+  });
+});

--- a/tests/github-pr-list/tsconfig.json
+++ b/tests/github-pr-list/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@extension/tsconfig/module",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "dist"
+  },
+  "include": ["src", "tests"]
+}


### PR DESCRIPTION
## Summary
- add new test package `github-pr-list`
- implement `listAllPullRequests` fetching all pull requests with pagination
- test pagination logic using nock and vitest

## Testing
- `pnpm --filter @tests/github-pr-list test`
- `pnpm lint` *(fails: `command exited (1)`)*

------
https://chatgpt.com/codex/tasks/task_e_688bc1eb71bc83249bb6c6f60603626c